### PR TITLE
Implementing button press time to trigger manual shutdown

### DIFF
--- a/Software/wittypi/daemon.sh
+++ b/Software/wittypi/daemon.sh
@@ -152,10 +152,34 @@ while true; do
       clear_alarm_flags
     else
     	# not shutdown by alarm
+      # wait for button to be pressed for SHUTDOWN_HOLD_TIME to prevent single accidental button shutdown
+      # by default this is set to 2 seconds, can be changed in utilities.sh
+      counter=0
+      while [ $counter -lt $SHUTDOWN_HOLD_TIME ]; do  # increase this value if it needs more time
+        if [ $(gpio -g read $HALT_PIN) == '1' ] ; then
+          counter=$(($counter+1))
+        else
+          counter=0
+          continue 2
+        fi
+        sleep 1
+      done
       break;
     fi
   else
     # power switch can still work without RTC
+    # wait for button to be pressed for SHUTDOWN_HOLD_TIME to prevent single accidental button shutdown
+    # by default this is set to 2 seconds, can be changed in utilities.sh
+    counter=0
+    while [ $counter -lt $SHUTDOWN_HOLD_TIME ]; do  # increase this value if it needs more time
+      if [ $(gpio -g read $HALT_PIN) == '1' ] ; then
+        counter=$(($counter+1))
+      else
+        counter=0
+        continue 2
+      fi
+      sleep 1
+    done
     break;
   fi
 done

--- a/Software/wittypi/utilities.sh
+++ b/Software/wittypi/utilities.sh
@@ -34,7 +34,7 @@ if [ -z ${I2C_RTC_ADDRESS+x} ]; then
 	
 	readonly HALT_PIN=4    # halt by GPIO-4 (BCM naming)
 	readonly SYSUP_PIN=17  # output SYS_UP signal on GPIO-17 (BCM naming)
-
+  readonly SHUTDOWN_HOLD_TIME=2 # hold power button for N seconds to trigger manual shutdown
 	readonly INTERNET_SERVER='http://google.com' # check network accessibility and get network time
 fi
 


### PR DESCRIPTION
Manual shutdown currently happens at first button tap, which could be accidental.
This patch implements a configurable time for the button to be held down before the shutdown script is triggered.
Hope you'll want to merge it, it's very useful :)

It would also be great if you could add this parameter to the configuration utility and save it to the Microcontroller's EEPROM so users could choose to have 1, 2, 3, 4 seconds to shut down manually, since 5 is the circuit's force shutdown time.

Thank you for your attention
u.